### PR TITLE
chore(release): bump changelog to version 2.0.0

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,7 @@ func New() *cli.App {
 		Name:        "changelog",
 		Usage:       "changelog [command]",
 		Description: "A changelog tool to manage changelog.",
-		Version:     "1.0.1",
+		Version:     "2.0.0",
 
 		// global flags
 		Flags: []cli.Flag{


### PR DESCRIPTION
Includes:

1. https://github.com/Kong/gateway-changelog/pull/18
2. https://github.com/Kong/gateway-changelog/pull/20