### PR TITLE
fix(git): get original changelog file's commit

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -76,15 +76,15 @@ func isYAML(filename string) bool {
 }
 
 func fetchCommitContext(filename string) (ctx CommitContext, err error) {
-	commits, err := utils.ListCommits("", filename)
+	commit, err := utils.FindOriginalCommit("", filename)
 	if err != nil {
 		return
 	}
 	if debug {
-		Debug("file %s commits: %v", filename, commits)
+		Debug("file %s original commit: %s", filename, commit)
 	}
 
-	prs, _, err := client.PullRequests.ListPullRequestsWithCommit(context.TODO(), options.GithubApiOwner, options.GithubApiRepo, commits[len(commits)-1], nil)
+	prs, _, err := client.PullRequests.ListPullRequestsWithCommit(context.TODO(), options.GithubApiOwner, options.GithubApiRepo, commit, nil)
 	if err != nil {
 		return ctx, fmt.Errorf("failed to fetch pulls: %v", err)
 	}

--- a/utils/git.go
+++ b/utils/git.go
@@ -1,38 +1,87 @@
 package utils
 
 import (
+	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
-// commitActuallyModifiedFile checks if a commit actually modified the file
-// (not just a rename in the history)
-func commitActuallyModifiedFile(workingDir, commit, filename string) bool {
-	// git diff-tree --no-commit-id --name-only -r <commit> -- <filename>
-	cmd := exec.Command("git", "diff-tree", "--no-commit-id", "--name-only", "-r", commit, "--", filename)
+// findRenameSource checks if a commit renamed a file to `filename`,
+// returns the old filename if it was a rename, otherwise returns "".
+func findRenameSource(workingDir, commit, filename string) string {
+	cmd := exec.Command("git", "diff-tree", "-r", "-M",
+		"--no-commit-id", "--diff-filter=R", "--name-status", commit)
 	cmd.Dir = workingDir
 	output, err := cmd.Output()
 	if err != nil {
-		return false
-	}
-	return strings.TrimSpace(string(output)) != ""
-}
-
-func ListCommits(workingDir, filename string) (commits []string, err error) {
-	// execute command git log --follow --pretty=format:%H  -- <path>
-	cmd := exec.Command("git", "log", "--follow", "--pretty=format:%H", "--", filename)
-	cmd.Dir = workingDir
-	output, err := cmd.Output()
-	if err != nil {
-		return
+		return ""
 	}
 
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		commit := strings.TrimSpace(line)
-		if commit != "" && commitActuallyModifiedFile(workingDir, commit, filename) {
-			commits = append(commits, commit)
+	// output format: R100\told-name\tnew-name
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		parts := strings.Split(line, "\t")
+		if len(parts) == 3 && filepath.Base(parts[2]) == filepath.Base(filename) {
+			oldName := filepath.Join(filepath.Dir(filename), filepath.Base(parts[1]))
+			return oldName
 		}
 	}
-	return
+	return ""
+}
+
+// findAddedCommit finds the commit where the file was first added.
+func findAddedCommit(workingDir, filename string) string {
+	cmd := exec.Command("git", "log", "--diff-filter=A",
+		"--pretty=format:%H", "--", filename)
+	cmd.Dir = workingDir
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return ""
+	}
+	lines := strings.Split(trimmed, "\n")
+	return strings.TrimSpace(lines[len(lines)-1])
+}
+
+// findOldestCommit returns the oldest commit that touched the file.
+func findOldestCommit(workingDir, filename string) string {
+	cmd := exec.Command("git", "log", "--pretty=format:%H", "--", filename)
+	cmd.Dir = workingDir
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return ""
+	}
+	lines := strings.Split(trimmed, "\n")
+	return strings.TrimSpace(lines[len(lines)-1])
+}
+
+// FindOriginalCommit traces back through renames to find
+// the commit that originally created the changelog file.
+func FindOriginalCommit(workingDir, filename string) (string, error) {
+	commit := findAddedCommit(workingDir, filename)
+	if commit == "" {
+		commit = findOldestCommit(workingDir, filename)
+		if commit == "" {
+			return "", fmt.Errorf("no commits found for %s", filename)
+		}
+		return commit, nil
+	}
+
+	oldName := findRenameSource(workingDir, commit, filename)
+	if oldName == "" {
+		return commit, nil
+	}
+
+	result, err := FindOriginalCommit(workingDir, oldName)
+	if err != nil || result == "" {
+		return commit, nil
+	}
+	return result, nil
 }


### PR DESCRIPTION
### Summary
Use recursion to search for the corresponding commit of the original changelog file that has been renamed.

### Issue reference
[FTI-7257](https://konghq.atlassian.net/browse/FTI-7257)

[FTI-7257]: https://konghq.atlassian.net/browse/FTI-7257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ