### PR TITLE
fix(git): prefer the current add commit when tracing file history

### DIFF
--- a/utils/git.go
+++ b/utils/git.go
@@ -43,7 +43,7 @@ func findAddedCommit(workingDir, filename string) string {
 		return ""
 	}
 	lines := strings.Split(trimmed, "\n")
-	return strings.TrimSpace(lines[len(lines)-1])
+	return strings.TrimSpace(lines[0])
 }
 
 // findOldestCommit returns the oldest commit that touched the file.


### PR DESCRIPTION
### Summary
Use the first SHA returned by `git log --diff-filter=A` when resolving the add commit for a file path. This keeps original commit lookup anchored to the current file instance instead of an older add event for the same path.

### Issue reference
[FTI-7495](https://konghq.atlassian.net/browse/FTI-7495)

[FTI-7495]: https://konghq.atlassian.net/browse/FTI-7495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ