### PR TITLE
fix(git): fix infinite recursion and rename tracking in FindOriginalCommit

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -76,7 +76,7 @@ func isYAML(filename string) bool {
 }
 
 func fetchCommitContext(filename string) (ctx CommitContext, err error) {
-	commit, err := utils.FindOriginalCommit("", filename)
+	commit, err := utils.FindOriginalCommit(options.RepoPath, filename)
 	if err != nil {
 		return
 	}

--- a/utils/git.go
+++ b/utils/git.go
@@ -2,10 +2,81 @@ package utils
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 )
+
+func normalizePath(filename string) string {
+	if filename == "" {
+		return ""
+	}
+
+	return filepath.Clean(filepath.FromSlash(filename))
+}
+
+func pathRelativeToWorkingDir(workingDir, filename string) string {
+	name := normalizePath(filename)
+	if !filepath.IsAbs(name) {
+		return name
+	}
+
+	dir := workingDir
+	if dir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return name
+		}
+		dir = cwd
+	}
+
+	relPath, err := filepath.Rel(dir, name)
+	if err != nil {
+		return name
+	}
+
+	return normalizePath(relPath)
+}
+
+func gitPrefix(workingDir string) string {
+	cmd := exec.Command("git", "rev-parse", "--show-prefix")
+	cmd.Dir = workingDir
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	return normalizePath(strings.TrimSpace(string(output)))
+}
+
+func trimGitPrefix(filename, prefix string) string {
+	name := normalizePath(filename)
+	prefix = normalizePath(prefix)
+	if prefix == "" || prefix == "." {
+		return name
+	}
+
+	trimmed, ok := strings.CutPrefix(name, prefix+string(filepath.Separator))
+	if ok {
+		return trimmed
+	}
+
+	return name
+}
+
+func resolveRenameSource(prefix, currentName, oldName, newName string) string {
+	if trimGitPrefix(newName, prefix) != normalizePath(currentName) {
+		return ""
+	}
+
+	oldPath := trimGitPrefix(oldName, prefix)
+	if oldPath == "" || oldPath == normalizePath(currentName) {
+		return ""
+	}
+
+	return oldPath
+}
 
 // findRenameSource checks if a commit renamed a file to `filename`,
 // returns the old filename if it was a rename, otherwise returns "".
@@ -18,11 +89,17 @@ func findRenameSource(workingDir, commit, filename string) string {
 		return ""
 	}
 
+	prefix := gitPrefix(workingDir)
+	currentName := pathRelativeToWorkingDir(workingDir, filename)
+
 	// output format: R100\told-name\tnew-name
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
 		parts := strings.Split(line, "\t")
-		if len(parts) == 3 && filepath.Base(parts[2]) == filepath.Base(filename) {
-			oldName := filepath.Join(filepath.Dir(filename), filepath.Base(parts[1]))
+		if len(parts) != 3 {
+			continue
+		}
+
+		if oldName := resolveRenameSource(prefix, currentName, parts[1], parts[2]); oldName != "" {
 			return oldName
 		}
 	}
@@ -31,6 +108,7 @@ func findRenameSource(workingDir, commit, filename string) string {
 
 // findAddedCommit finds the commit where the file was first added.
 func findAddedCommit(workingDir, filename string) string {
+	filename = pathRelativeToWorkingDir(workingDir, filename)
 	cmd := exec.Command("git", "log", "--diff-filter=A",
 		"--pretty=format:%H", "--", filename)
 	cmd.Dir = workingDir
@@ -48,6 +126,7 @@ func findAddedCommit(workingDir, filename string) string {
 
 // findOldestCommit returns the oldest commit that touched the file.
 func findOldestCommit(workingDir, filename string) string {
+	filename = pathRelativeToWorkingDir(workingDir, filename)
 	cmd := exec.Command("git", "log", "--pretty=format:%H", "--", filename)
 	cmd.Dir = workingDir
 	output, err := cmd.Output()
@@ -65,13 +144,22 @@ func findOldestCommit(workingDir, filename string) string {
 // FindOriginalCommit traces back through renames to find
 // the commit that originally created the changelog file.
 func FindOriginalCommit(workingDir, filename string) (string, error) {
+	return findOriginalCommit(workingDir, filename, make(map[string]bool))
+}
+
+func findOriginalCommit(workingDir, filename string, visited map[string]bool) (string, error) {
+	key := normalizePath(pathRelativeToWorkingDir(workingDir, filename))
+	if visited[key] {
+		return "", fmt.Errorf("cycle detected for %s", filename)
+	}
+	visited[key] = true
+
 	commit := findAddedCommit(workingDir, filename)
 	if commit == "" {
 		commit = findOldestCommit(workingDir, filename)
 		if commit == "" {
 			return "", fmt.Errorf("no commits found for %s", filename)
 		}
-		return commit, nil
 	}
 
 	oldName := findRenameSource(workingDir, commit, filename)
@@ -79,7 +167,7 @@ func FindOriginalCommit(workingDir, filename string) (string, error) {
 		return commit, nil
 	}
 
-	result, err := FindOriginalCommit(workingDir, oldName)
+	result, err := findOriginalCommit(workingDir, oldName, visited)
 	if err != nil || result == "" {
 		return commit, nil
 	}


### PR DESCRIPTION
### Summary

- **Fix infinite recursion**: `findRenameSource` previously matched renames by
  basename only, causing `oldName` to collapse to the same path as `filename`
  when a file was moved across directories (e.g. `unreleased/kong-ee/foo.yml` →
  `3.13.0.4/kong-ee/foo.yml`). This caused `FindOriginalCommit` to recurse
  infinitely, hanging the changelog generator. Fixed by replacing basename
  matching with full-path comparison via `resolveRenameSource`.

- **Fix early return skipping rename detection**: When `--diff-filter=A` returns
  empty (git marks a moved file as `R` rather than `A`), the fallback to
  `findOldestCommit` previously returned immediately without checking for
  renames. This caused changelog files in versioned folders to resolve to the
  release/move commit instead of the original PR commit. The early return is
  removed so the fallback path also checks for renames.

- **Add cycle detection**: Introduced a `visited` map passed through the
  recursion to guard against any multi-step rename cycle (A→B→A), replacing the
  prior single-level self-reference guard.

### Issue

[KAG-8786](https://konghq.atlassian.net/browse/KAG-8786)

[KAG-8786]: https://konghq.atlassian.net/browse/KAG-8786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ