### PR TITLE
fix(*): combine git history fixes, PR lookup handling, and changelog signature cleanup fixes

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -9,7 +9,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -71,8 +73,61 @@ type PullRequestContext struct {
 	Body   string
 }
 
+var pullRequestRefPattern = regexp.MustCompile(`\(#(\d+)\)`)
+
 func isYAML(filename string) bool {
 	return strings.HasSuffix(filename, ".yml")
+}
+
+func findMergedPullRequest(prs []*github.PullRequest) *github.PullRequest {
+	for i := len(prs) - 1; i >= 0; i-- {
+		if prs[i].MergedAt != nil {
+			return prs[i]
+		}
+	}
+
+	return nil
+}
+
+func fetchMergedPullRequestFromCommitMessage(commit string) (*github.PullRequest, error) {
+	repoCommit, _, err := client.Repositories.GetCommit(context.TODO(), options.GithubApiOwner, options.GithubApiRepo, commit, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read commit message for %s: %v", commit, err)
+	}
+
+	matches := pullRequestRefPattern.FindAllStringSubmatch(repoCommit.GetCommit().GetMessage(), -1)
+	if len(matches) == 0 {
+		return nil, nil
+	}
+
+	seen := make(map[int]struct{}, len(matches))
+	for i := len(matches) - 1; i >= 0; i-- {
+		prNumber, err := strconv.Atoi(matches[i][1])
+		if err != nil {
+			continue
+		}
+
+		if _, ok := seen[prNumber]; ok {
+			continue
+		}
+		seen[prNumber] = struct{}{}
+
+		pr, resp, err := client.PullRequests.Get(context.TODO(), options.GithubApiOwner, options.GithubApiRepo, prNumber)
+		if err != nil {
+			if debug && (resp == nil || resp.StatusCode != http.StatusNotFound) {
+				Debug("failed to fetch PR #%d for commit %s: %v", prNumber, commit, err)
+			}
+			continue
+		}
+		if pr.MergedAt == nil {
+			continue
+		}
+		if pr.GetMergeCommitSHA() == commit {
+			return pr, nil
+		}
+	}
+
+	return nil, nil
 }
 
 func fetchCommitContext(filename string) (ctx CommitContext, err error) {
@@ -80,29 +135,29 @@ func fetchCommitContext(filename string) (ctx CommitContext, err error) {
 	if err != nil {
 		return
 	}
+	ctx.SHA = commit
 	if debug {
 		Debug("file %s original commit: %s", filename, commit)
 	}
 
 	prs, _, err := client.PullRequests.ListPullRequestsWithCommit(context.TODO(), options.GithubApiOwner, options.GithubApiRepo, commit, nil)
 	if err != nil {
-		return ctx, fmt.Errorf("failed to fetch pulls: %v", err)
-	}
-	if len(prs) == 0 {
-		return ctx, fmt.Errorf("PullReqeusts is empty")
+		return ctx, fmt.Errorf("failed to fetch pulls for commit %s: %v", commit, err)
 	}
 
-	// Filter to find only merged PRs, starting from the last one
-	var mergedPR *github.PullRequest
-	for i := len(prs) - 1; i >= 0; i-- {
-		if prs[i].MergedAt != nil {
-			mergedPR = prs[i]
-			break
+	mergedPR := findMergedPullRequest(prs)
+	if mergedPR == nil {
+		mergedPR, err = fetchMergedPullRequestFromCommitMessage(commit)
+		if err != nil {
+			return ctx, fmt.Errorf("failed to resolve merged PR from commit message: %v", err)
+		}
+		if debug && mergedPR != nil {
+			Debug("resolved merged PR #%d from commit message for %s", mergedPR.GetNumber(), commit)
 		}
 	}
 
 	if mergedPR == nil {
-		return ctx, fmt.Errorf("no merged PR found for commit")
+		return ctx, fmt.Errorf("no merged PR found for commit %s", commit)
 	}
 
 	ctx.PrCtx = PullRequestContext{
@@ -166,7 +221,7 @@ func processEntry(entry *ChangelogEntry) error {
 
 	ctx, err := fetchCommitContext(entry.fileName)
 	if err != nil {
-		return fmt.Errorf("faield to fetch commit ctx: %v", err)
+		return fmt.Errorf("failed to fetch commit ctx: %v", err)
 	}
 
 	// jiras
@@ -253,7 +308,7 @@ func collectFromFolder(repoPath string, changelogPath string, maps map[string]ma
 
 		err = processEntry(entry)
 		if err != nil {
-			return fmt.Errorf("fialed to process entry: %v", err)
+			return fmt.Errorf("failed to process entry: %v", err)
 		}
 
 		if maps[entry.Type] == nil {

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -73,6 +73,84 @@ type PullRequestContext struct {
 	Body   string
 }
 
+type MissingPullRequestError struct {
+	CommitSHA string
+}
+
+func (e *MissingPullRequestError) Error() string {
+	return fmt.Sprintf("no merged PR found for commit %s", e.CommitSHA)
+}
+
+type EntryProcessingFailure struct {
+	FileName  string
+	CommitSHA string
+	Err       error
+}
+
+func (e *EntryProcessingFailure) Error() string {
+	var missingPR *MissingPullRequestError
+	if errors.As(e.Err, &missingPR) {
+		return fmt.Sprintf("reason: missing merged PR\nfile: %s\ncommit: %s", e.FileName, missingPR.CommitSHA)
+	}
+
+	if e.CommitSHA == "" {
+		return fmt.Sprintf("file: %s\nerror: %v", e.FileName, e.Err)
+	}
+
+	return fmt.Sprintf("file: %s\ncommit: %s\nerror: %v", e.FileName, e.CommitSHA, e.Err)
+}
+
+func (e *EntryProcessingFailure) Unwrap() error {
+	return e.Err
+}
+
+func logEntryProcessingFailure(failure EntryProcessingFailure) {
+	Error("skipping changelog entry: %s\n", strings.ReplaceAll(failure.Error(), "\n", "\n  "))
+}
+
+func logEntryProcessingSummary(failures []EntryProcessingFailure) {
+	if len(failures) == 0 {
+		return
+	}
+
+	entryNoun := "entries"
+	if len(failures) == 1 {
+		entryNoun = "entry"
+	}
+
+	Error("\nskipped %d changelog %s:\n", len(failures), entryNoun)
+	for i, failure := range failures {
+		Error("%d. %s\n", i+1, strings.ReplaceAll(failure.Error(), "\n", "\n   "))
+	}
+}
+
+func entryProcessingFailureFromError(err error, fileName string) *EntryProcessingFailure {
+	var failure *EntryProcessingFailure
+	if errors.As(err, &failure) {
+		if failure.FileName == "" {
+			failure.FileName = fileName
+		}
+		if failure.CommitSHA == "" {
+			var missingPR *MissingPullRequestError
+			if errors.As(failure.Err, &missingPR) {
+				failure.CommitSHA = missingPR.CommitSHA
+			}
+		}
+		return failure
+	}
+
+	var missingPR *MissingPullRequestError
+	if !errors.As(err, &missingPR) {
+		return nil
+	}
+
+	return &EntryProcessingFailure{
+		FileName:  fileName,
+		CommitSHA: missingPR.CommitSHA,
+		Err:       err,
+	}
+}
+
 var pullRequestRefPattern = regexp.MustCompile(`\(#(\d+)\)`)
 
 func isYAML(filename string) bool {
@@ -157,7 +235,7 @@ func fetchCommitContext(filename string) (ctx CommitContext, err error) {
 	}
 
 	if mergedPR == nil {
-		return ctx, fmt.Errorf("no merged PR found for commit %s", commit)
+		return ctx, &MissingPullRequestError{CommitSHA: commit}
 	}
 
 	ctx.PrCtx = PullRequestContext{
@@ -221,7 +299,17 @@ func processEntry(entry *ChangelogEntry) error {
 
 	ctx, err := fetchCommitContext(entry.fileName)
 	if err != nil {
-		return fmt.Errorf("failed to fetch commit ctx: %v", err)
+		var missingPR *MissingPullRequestError
+		var noCommits *utils.NoCommitsFoundError
+		if !errors.As(err, &missingPR) && !errors.As(err, &noCommits) {
+			return fmt.Errorf("failed to fetch commit ctx: %v", err)
+		}
+
+		return &EntryProcessingFailure{
+			FileName:  entry.fileName,
+			CommitSHA: ctx.SHA,
+			Err:       fmt.Errorf("failed to fetch commit ctx: %w", err),
+		}
 	}
 
 	// jiras
@@ -266,16 +354,17 @@ func mapKeys(m map[string][]*ChangelogEntry) []string {
 	return keys
 }
 
-func collectFromFolder(repoPath string, changelogPath string, maps map[string]map[string][]*ChangelogEntry) error {
+func collectFromFolder(repoPath string, changelogPath string, maps map[string]map[string][]*ChangelogEntry) ([]EntryProcessingFailure, error) {
+	failures := make([]EntryProcessingFailure, 0)
 	changelogPath = filepath.Join(repoPath, changelogPath)
 	exists, err := utils.DirExists(changelogPath)
 	if !exists {
-		return err
+		return failures, err
 	}
 
 	files, err := os.ReadDir(changelogPath)
 	if err != nil {
-		return err
+		return failures, err
 	}
 	total := len(files)
 	Info("reading files from folder %s", changelogPath)
@@ -290,9 +379,11 @@ func collectFromFolder(repoPath string, changelogPath string, maps map[string]ma
 			continue
 		}
 
-		content, err := os.ReadFile(filepath.Join(changelogPath, file.Name()))
+		filePath := filepath.Join(changelogPath, file.Name())
+
+		content, err := os.ReadFile(filePath)
 		if err != nil {
-			return err
+			return failures, err
 		}
 
 		Info("processing changelog file: %s (%d/%d)", file.Name(), i, total)
@@ -301,14 +392,21 @@ func collectFromFolder(repoPath string, changelogPath string, maps map[string]ma
 		entry := &ChangelogEntry{}
 		err = yaml.Unmarshal(content, entry)
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal YAML from %s: %v", file.Name(), err)
+			return failures, fmt.Errorf("failed to unmarshal YAML from %s: %v", file.Name(), err)
 		}
 
-		entry.fileName = filepath.Join(changelogPath, file.Name())
+		entry.fileName = filePath
 
 		err = processEntry(entry)
 		if err != nil {
-			return fmt.Errorf("failed to process entry: %v", err)
+			failure := entryProcessingFailureFromError(err, filePath)
+			if failure == nil {
+				return failures, fmt.Errorf("failed to process entry: %v", err)
+			}
+
+			logEntryProcessingFailure(*failure)
+			failures = append(failures, *failure)
+			continue
 		}
 
 		if maps[entry.Type] == nil {
@@ -317,16 +415,18 @@ func collectFromFolder(repoPath string, changelogPath string, maps map[string]ma
 		maps[entry.Type][entry.Scope] = append(maps[entry.Type][entry.Scope], entry)
 	}
 
-	return nil
+	return failures, nil
 }
 
-func collect() (*TemplateData, error) {
+func collect() (*TemplateData, []EntryProcessingFailure, error) {
 	maps := make(map[string]map[string][]*ChangelogEntry)
+	failures := make([]EntryProcessingFailure, 0)
 
 	for _, path := range options.ChangelogPaths {
-		err := collectFromFolder(options.RepoPath, path, maps)
+		folderFailures, err := collectFromFolder(options.RepoPath, path, maps)
+		failures = append(failures, folderFailures...)
 		if err != nil {
-			return nil, err
+			return nil, failures, err
 		}
 	}
 
@@ -354,7 +454,7 @@ func collect() (*TemplateData, error) {
 		data.Type[t] = list
 	}
 
-	return data, nil
+	return data, failures, nil
 }
 
 func generate(data *TemplateData) error {
@@ -413,7 +513,8 @@ func generate(data *TemplateData) error {
 func Generate() error {
 	Debug("Options: %+v", options)
 
-	data, err := collect()
+	data, failures, err := collect()
+	logEntryProcessingSummary(failures)
 	if err != nil {
 		return err
 	}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -76,7 +76,7 @@ func isYAML(filename string) bool {
 }
 
 func fetchCommitContext(filename string) (ctx CommitContext, err error) {
-	commit, err := utils.FindOriginalCommit("", filename)
+	commit, err := utils.FindOriginalCommit(options.RepoPath, filename)
 	if err != nil {
 		return
 	}

--- a/utils/git.go
+++ b/utils/git.go
@@ -43,7 +43,7 @@ func findAddedCommit(workingDir, filename string) string {
 		return ""
 	}
 	lines := strings.Split(trimmed, "\n")
-	return strings.TrimSpace(lines[len(lines)-1])
+	return strings.TrimSpace(lines[0])
 }
 
 // findOldestCommit returns the oldest commit that touched the file.

--- a/utils/git.go
+++ b/utils/git.go
@@ -31,7 +31,7 @@ func findRenameSource(workingDir, commit, filename string) string {
 
 // findAddedCommit finds the commit where the file was first added.
 func findAddedCommit(workingDir, filename string) string {
-	cmd := exec.Command("git", "log", "--diff-filter=A",
+	cmd := exec.Command("git", "log", "--diff-filter=A", "--no-show-signature",
 		"--pretty=format:%H", "--", filename)
 	cmd.Dir = workingDir
 	output, err := cmd.Output()
@@ -48,7 +48,7 @@ func findAddedCommit(workingDir, filename string) string {
 
 // findOldestCommit returns the oldest commit that touched the file.
 func findOldestCommit(workingDir, filename string) string {
-	cmd := exec.Command("git", "log", "--pretty=format:%H", "--", filename)
+	cmd := exec.Command("git", "log", "--no-show-signature", "--pretty=format:%H", "--", filename)
 	cmd.Dir = workingDir
 	output, err := cmd.Output()
 	if err != nil {

--- a/utils/git.go
+++ b/utils/git.go
@@ -2,10 +2,81 @@ package utils
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 )
+
+func normalizePath(filename string) string {
+	if filename == "" {
+		return ""
+	}
+
+	return filepath.Clean(filepath.FromSlash(filename))
+}
+
+func pathRelativeToWorkingDir(workingDir, filename string) string {
+	name := normalizePath(filename)
+	if !filepath.IsAbs(name) {
+		return name
+	}
+
+	dir := workingDir
+	if dir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return name
+		}
+		dir = cwd
+	}
+
+	relPath, err := filepath.Rel(dir, name)
+	if err != nil {
+		return name
+	}
+
+	return normalizePath(relPath)
+}
+
+func gitPrefix(workingDir string) string {
+	cmd := exec.Command("git", "rev-parse", "--show-prefix")
+	cmd.Dir = workingDir
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	return normalizePath(strings.TrimSpace(string(output)))
+}
+
+func trimGitPrefix(filename, prefix string) string {
+	name := normalizePath(filename)
+	prefix = normalizePath(prefix)
+	if prefix == "" || prefix == "." {
+		return name
+	}
+
+	trimmed, ok := strings.CutPrefix(name, prefix+string(filepath.Separator))
+	if ok {
+		return trimmed
+	}
+
+	return name
+}
+
+func resolveRenameSource(prefix, currentName, oldName, newName string) string {
+	if trimGitPrefix(newName, prefix) != normalizePath(currentName) {
+		return ""
+	}
+
+	oldPath := trimGitPrefix(oldName, prefix)
+	if oldPath == "" || oldPath == normalizePath(currentName) {
+		return ""
+	}
+
+	return oldPath
+}
 
 // findRenameSource checks if a commit renamed a file to `filename`,
 // returns the old filename if it was a rename, otherwise returns "".
@@ -18,11 +89,17 @@ func findRenameSource(workingDir, commit, filename string) string {
 		return ""
 	}
 
+	prefix := gitPrefix(workingDir)
+	currentName := pathRelativeToWorkingDir(workingDir, filename)
+
 	// output format: R100\told-name\tnew-name
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
 		parts := strings.Split(line, "\t")
-		if len(parts) == 3 && filepath.Base(parts[2]) == filepath.Base(filename) {
-			oldName := filepath.Join(filepath.Dir(filename), filepath.Base(parts[1]))
+		if len(parts) != 3 {
+			continue
+		}
+
+		if oldName := resolveRenameSource(prefix, currentName, parts[1], parts[2]); oldName != "" {
 			return oldName
 		}
 	}
@@ -31,6 +108,7 @@ func findRenameSource(workingDir, commit, filename string) string {
 
 // findAddedCommit finds the commit where the file was first added.
 func findAddedCommit(workingDir, filename string) string {
+	filename = pathRelativeToWorkingDir(workingDir, filename)
 	cmd := exec.Command("git", "log", "--diff-filter=A",
 		"--pretty=format:%H", "--", filename)
 	cmd.Dir = workingDir
@@ -48,6 +126,7 @@ func findAddedCommit(workingDir, filename string) string {
 
 // findOldestCommit returns the oldest commit that touched the file.
 func findOldestCommit(workingDir, filename string) string {
+	filename = pathRelativeToWorkingDir(workingDir, filename)
 	cmd := exec.Command("git", "log", "--pretty=format:%H", "--", filename)
 	cmd.Dir = workingDir
 	output, err := cmd.Output()
@@ -65,13 +144,22 @@ func findOldestCommit(workingDir, filename string) string {
 // FindOriginalCommit traces back through renames to find
 // the commit that originally created the changelog file.
 func FindOriginalCommit(workingDir, filename string) (string, error) {
+	return findOriginalCommit(workingDir, filename, make(map[string]bool))
+}
+
+func findOriginalCommit(workingDir, filename string, visited map[string]bool) (string, error) {
+	key := normalizePath(pathRelativeToWorkingDir(workingDir, filename))
+	if visited[key] {
+		return "", fmt.Errorf("cycle detected for %s", filename)
+	}
+	visited[key] = true
+
 	commit := findAddedCommit(workingDir, filename)
 	if commit == "" {
 		commit = findOldestCommit(workingDir, filename)
 		if commit == "" {
 			return "", fmt.Errorf("no commits found for %s", filename)
 		}
-		return commit, nil
 	}
 
 	oldName := findRenameSource(workingDir, commit, filename)
@@ -79,7 +167,7 @@ func FindOriginalCommit(workingDir, filename string) (string, error) {
 		return commit, nil
 	}
 
-	result, err := FindOriginalCommit(workingDir, oldName)
+	result, err := findOriginalCommit(workingDir, oldName, visited)
 	if err != nil || result == "" {
 		return commit, nil
 	}

--- a/utils/git.go
+++ b/utils/git.go
@@ -7,6 +7,14 @@ import (
 	"strings"
 )
 
+type NoCommitsFoundError struct {
+	FileName string
+}
+
+func (e *NoCommitsFoundError) Error() string {
+	return fmt.Sprintf("no commits found for %s", e.FileName)
+}
+
 // findRenameSource checks if a commit renamed a file to `filename`,
 // returns the old filename if it was a rename, otherwise returns "".
 func findRenameSource(workingDir, commit, filename string) string {
@@ -69,7 +77,7 @@ func FindOriginalCommit(workingDir, filename string) (string, error) {
 	if commit == "" {
 		commit = findOldestCommit(workingDir, filename)
 		if commit == "" {
-			return "", fmt.Errorf("no commits found for %s", filename)
+			return "", &NoCommitsFoundError{FileName: filename}
 		}
 		return commit, nil
 	}


### PR DESCRIPTION
### Summary

This PR combines a set of changelog generation and git history fixes to make changelog processing more reliable for renamed files, backports, and merge edge cases.

It includes:
- fixing infinite recursion when tracing the original commit for renamed changelog files
- preferring the current file's add commit when resolving file history
- falling back to PR references in commit messages when merged PR lookup cannot resolve backport PRs
- logging and skipping changelog entries when merged PR lookup fails instead of failing the whole run
- suppressing git signature output in changelog-related git log calls

#### Why

Changelog generation was fragile in a few cases:
- renamed changelog files could recurse incorrectly while tracing original history
- `git log --diff-filter=A` handling could pick an older add event for the same path instead of the current file instance
- backport commits could miss merged PR resolution
- a single merged PR lookup failure could block the entire generation flow
- git signature output could leak into command output and pollute parsing

These changes make the generator more tolerant and more accurate when resolving changelog provenance.

This PR aggregates: #30 #29 #28 #27 #26 
### Issue

[KAG-8786](https://konghq.atlassian.net/browse/KAG-8786)

[KAG-8786]: https://konghq.atlassian.net/browse/KAG-8786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ