### PR TITLE
feat(schema): require bold plugin-name prefix in message when scope is Plugin

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,3 +24,12 @@ runs:
       with:
         jsonSchemaFile: gateway-changelog/changelog-schema.json
         yamlFiles: ${{ inputs.files }}
+
+    - name: explain validation errors
+      if: failure()
+      shell: bash
+      run: |
+        echo '::error::Changelog validation failed. Common causes:'
+        echo '::error::- message: 1-1000 characters, required'
+        echo '::error::- type: one of feature, bugfix, dependency, deprecation, breaking_change, performance (required)'
+        echo '::error::- scope "Plugin": message must start with the plugin name in bold followed by a space, e.g. "**rate-limiting** Fixed an issue ..."'

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,7 @@ runs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         repository: Kong/gateway-changelog
+        ref: ${{ github.action_ref }}
         path: gateway-changelog
 
     - name: validates changelogs

--- a/action.yml
+++ b/action.yml
@@ -10,11 +10,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      with:
-        repository: Kong/gateway-changelog
-        ref: ${{ github.action_ref }}
-        path: gateway-changelog
+    # The action repo is already downloaded at the pinned ref into
+    # GITHUB_ACTION_PATH, so copy the schema from there instead of
+    # checking out again (which would not honor the pinned ref).
+    - name: prepare changelog schema
+      shell: bash
+      run: |
+        mkdir -p gateway-changelog
+        cp "${GITHUB_ACTION_PATH}/changelog-schema.json" gateway-changelog/changelog-schema.json
 
     - name: validates changelogs
       uses: thiagodnf/yaml-schema-checker@3c4a632d4124b6c00e38b492b2eb35dea715e1ae # v0.0.12

--- a/action.yml
+++ b/action.yml
@@ -28,4 +28,4 @@ runs:
     - name: explain validation errors
       if: failure()
       shell: bash
-      run: python3 "${GITHUB_ACTION_PATH}/scripts/explain-changelog-errors.py" "${GITHUB_ACTION_PATH}/changelog-schema.json" '${{ inputs.files }}'
+      run: python3 "${GITHUB_ACTION_PATH}/scripts/explain-changelog-errors.py" "gateway-changelog/changelog-schema.json" '${{ inputs.files }}'

--- a/action.yml
+++ b/action.yml
@@ -28,8 +28,4 @@ runs:
     - name: explain validation errors
       if: failure()
       shell: bash
-      run: |
-        echo '::error::Changelog validation failed. Common causes:'
-        echo '::error::- message: 1-1000 characters, required'
-        echo '::error::- type: one of feature, bugfix, dependency, deprecation, breaking_change, performance (required)'
-        echo '::error::- scope "Plugin": message must start with the plugin name in bold followed by a space, e.g. "**rate-limiting** Fixed an issue ..."'
+      run: python3 "${GITHUB_ACTION_PATH}/scripts/explain-changelog-errors.py" "${GITHUB_ACTION_PATH}/changelog-schema.json" '${{ inputs.files }}'

--- a/changelog-schema.json
+++ b/changelog-schema.json
@@ -63,5 +63,19 @@
   "required": [
     "message",
     "type"
-  ]
+  ],
+  "if": {
+    "required": [ "scope" ],
+    "properties": {
+      "scope": { "const": "Plugin" }
+    }
+  },
+  "then": {
+    "properties": {
+      "message": {
+        "pattern": "^\\*\\*[^*\\s][^*]*\\*\\*:? ",
+        "description": "When scope is Plugin, message must start with the plugin name in bold, e.g. \"**rate-limiting** ...\""
+      }
+    }
+  }
 }

--- a/changelog-schema.json
+++ b/changelog-schema.json
@@ -74,10 +74,7 @@
     "properties": {
       "message": {
         "pattern": "^\\*\\*[^*\\s]([^*]*[^*\\s])?\\*\\*:? ",
-        "description": "When scope is Plugin, message must start with the plugin name in bold, e.g. \"**rate-limiting** ...\"",
-        "message": {
-          "pattern": "must start with the plugin name in bold when scope is \"Plugin\", e.g. \"**rate-limiting** Fixed an issue ...\""
-        }
+        "description": "When scope is Plugin, message must start with the plugin name in bold, e.g. \"**rate-limiting** ...\""
       }
     }
   }

--- a/changelog-schema.json
+++ b/changelog-schema.json
@@ -73,7 +73,7 @@
   "then": {
     "properties": {
       "message": {
-        "pattern": "^\\*\\*[^*\\s]([^*]*[^*\\s])?\\*\\*(, ?\\*\\*[^*\\s]([^*]*[^*\\s])?\\*\\*)*:? ",
+        "pattern": "^(?:\\*\\*[^*\\s](?:[^*]*[^*\\s])?\\*\\*)(?:, ?\\*\\*[^*\\s](?:[^*]*[^*\\s])?\\*\\*)*:? ",
         "description": "When scope is Plugin, message must start with one or more comma-separated plugin names in bold, e.g. \"**rate-limiting** ...\" or \"**kafka-upstream**, **confluent**: ...\""
       }
     }

--- a/changelog-schema.json
+++ b/changelog-schema.json
@@ -64,6 +64,7 @@
     "message",
     "type"
   ],
+  "additionalProperties": false,
   "if": {
     "required": [ "scope" ],
     "properties": {

--- a/changelog-schema.json
+++ b/changelog-schema.json
@@ -73,8 +73,11 @@
   "then": {
     "properties": {
       "message": {
-        "pattern": "^\\*\\*[^*\\s][^*]*\\*\\*:? ",
-        "description": "When scope is Plugin, message must start with the plugin name in bold, e.g. \"**rate-limiting** ...\""
+        "pattern": "^\\*\\*[^*\\s]([^*]*[^*\\s])?\\*\\*:? ",
+        "description": "When scope is Plugin, message must start with the plugin name in bold, e.g. \"**rate-limiting** ...\"",
+        "message": {
+          "pattern": "must start with the plugin name in bold when scope is \"Plugin\", e.g. \"**rate-limiting** Fixed an issue ...\""
+        }
       }
     }
   }

--- a/changelog-schema.json
+++ b/changelog-schema.json
@@ -73,8 +73,8 @@
   "then": {
     "properties": {
       "message": {
-        "pattern": "^\\*\\*[^*\\s]([^*]*[^*\\s])?\\*\\*:? ",
-        "description": "When scope is Plugin, message must start with the plugin name in bold, e.g. \"**rate-limiting** ...\""
+        "pattern": "^\\*\\*[^*\\s]([^*]*[^*\\s])?\\*\\*(, ?\\*\\*[^*\\s]([^*]*[^*\\s])?\\*\\*)*:? ",
+        "description": "When scope is Plugin, message must start with one or more comma-separated plugin names in bold, e.g. \"**rate-limiting** ...\" or \"**kafka-upstream**, **confluent**: ...\""
       }
     }
   }

--- a/scripts/explain-changelog-errors.py
+++ b/scripts/explain-changelog-errors.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Re-check changelog files against changelog-schema.json and print one
+GitHub error annotation per violation, with a human-readable reason.
+
+Runs only after yaml-schema-checker has already failed the job, so this
+script is best-effort: it exits 0 regardless, and the schema stays the
+single source of truth (enums and the Plugin message pattern are read
+from it).
+
+Usage: explain-changelog-errors.py <schema.json> <comma-separated globs>
+"""
+
+import glob
+import json
+import re
+import sys
+
+
+def error(file, msg):
+    print(f"::error file={file}::{file}: {msg}")
+
+
+def main():
+    schema_file, patterns = sys.argv[1], sys.argv[2]
+
+    with open(schema_file) as f:
+        schema = json.load(f)
+
+    props = schema["properties"]
+    type_enum = props["type"]["enum"]
+    scope_enum = props["scope"]["enum"]
+    jira_pattern = props["jiras"]["items"]["pattern"]
+    msg_min = props["message"]["minLength"]
+    msg_max = props["message"]["maxLength"]
+    plugin_pattern = schema["then"]["properties"]["message"]["pattern"]
+
+    try:
+        import yaml
+    except ImportError:
+        print("::warning::PyYAML unavailable; cannot print detailed changelog hints")
+        return
+
+    files = []
+    for pattern in patterns.split(","):
+        files.extend(sorted(glob.glob(pattern.strip(), recursive=True)))
+    if not files:
+        print(f"::warning::no changelog files matched: {patterns}")
+        return
+
+    for file in files:
+        try:
+            with open(file) as f:
+                doc = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            error(file, f"invalid YAML: {e}")
+            continue
+
+        if not isinstance(doc, dict):
+            error(file, "changelog must be a YAML mapping with 'message' and 'type' keys")
+            continue
+
+        message = doc.get("message")
+        if message is None:
+            error(file, "'message' is required")
+        elif not isinstance(message, str):
+            error(file, "'message' must be a string")
+        elif not (msg_min <= len(message) <= msg_max):
+            error(file, f"'message' must be {msg_min}-{msg_max} characters, got {len(message)}")
+
+        type_ = doc.get("type")
+        if type_ is None:
+            error(file, "'type' is required")
+        elif type_ not in type_enum:
+            error(file, f"'type' must be one of {', '.join(type_enum)}; got \"{type_}\"")
+
+        scope = doc.get("scope")
+        if scope is not None and scope not in scope_enum:
+            error(file, f"'scope' must be one of {', '.join(scope_enum)}; got \"{scope}\"")
+
+        if scope == "Plugin" and isinstance(message, str) and not re.match(plugin_pattern, message):
+            error(file, "scope is \"Plugin\", so 'message' must start with the plugin name "
+                        "in bold followed by a space, e.g. \"**rate-limiting** Fixed an issue ...\"")
+
+        for key in ("prs", "githubs"):
+            val = doc.get(key)
+            if val is not None:
+                if not isinstance(val, list) or any(not isinstance(i, int) or isinstance(i, bool) for i in val):
+                    error(file, f"'{key}' must be a list of integers, e.g. [1001, 1002]")
+
+        jiras = doc.get("jiras")
+        if jiras is not None:
+            if not isinstance(jiras, list):
+                error(file, "'jiras' must be a list of Jira ticket IDs, e.g. [\"FTI-1234\"]")
+            else:
+                for j in jiras:
+                    if not isinstance(j, str) or not re.match(jira_pattern, j):
+                        error(file, f"'jiras' entry \"{j}\" must look like a Jira ticket ID, e.g. \"FTI-1234\"")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/explain-changelog-errors.py
+++ b/scripts/explain-changelog-errors.py
@@ -78,10 +78,16 @@ def main():
             error(file, f"'scope' must be one of {', '.join(scope_enum)}; got \"{scope}\"")
 
         if scope == "Plugin" and isinstance(message, str) and not re.match(plugin_pattern, message):
+            head = message.splitlines()[0][:60] if message else ""
+            hint = ""
+            if message.startswith(('"', "'")):
+                hint = (" Note: the message starts with a quote character — quotes inside a "
+                        "YAML block scalar (| or >) are part of the content; remove them.")
             error(file, "scope is \"Plugin\", so 'message' must start with one or more "
                         "comma-separated plugin names in bold, followed by a space, e.g. "
                         "\"**rate-limiting** Fixed an issue ...\" or "
-                        "\"**kafka-upstream**, **confluent**: Added ...\"")
+                        "\"**kafka-upstream**, **confluent**: Added ...\". "
+                        f"Actual message starts with: {head!r}.{hint}")
 
         for key in ("prs", "githubs"):
             val = doc.get(key)

--- a/scripts/explain-changelog-errors.py
+++ b/scripts/explain-changelog-errors.py
@@ -78,8 +78,10 @@ def main():
             error(file, f"'scope' must be one of {', '.join(scope_enum)}; got \"{scope}\"")
 
         if scope == "Plugin" and isinstance(message, str) and not re.match(plugin_pattern, message):
-            error(file, "scope is \"Plugin\", so 'message' must start with the plugin name "
-                        "in bold followed by a space, e.g. \"**rate-limiting** Fixed an issue ...\"")
+            error(file, "scope is \"Plugin\", so 'message' must start with one or more "
+                        "comma-separated plugin names in bold, followed by a space, e.g. "
+                        "\"**rate-limiting** Fixed an issue ...\" or "
+                        "\"**kafka-upstream**, **confluent**: Added ...\"")
 
         for key in ("prs", "githubs"):
             val = doc.get(key)

--- a/scripts/explain-changelog-errors.py
+++ b/scripts/explain-changelog-errors.py
@@ -59,6 +59,17 @@ def main():
             error(file, "changelog must be a YAML mapping with 'message' and 'type' keys")
             continue
 
+        # keys are case-sensitive: "Scope: Plugin" silently becomes an
+        # unknown key and the entry loses its scope
+        for key in doc:
+            if key in props:
+                continue
+            lowered = str(key).lower()
+            if lowered in props:
+                error(file, f"unknown key \"{key}\" — keys are case-sensitive; did you mean '{lowered}'?")
+            else:
+                error(file, f"unknown key \"{key}\" — allowed keys: {', '.join(props)}")
+
         message = doc.get("message")
         if message is None:
             error(file, "'message' is required")
@@ -67,15 +78,22 @@ def main():
         elif not (msg_min <= len(message) <= msg_max):
             error(file, f"'message' must be {msg_min}-{msg_max} characters, got {len(message)}")
 
+        def enum_error(field, value, enum):
+            match = next((e for e in enum if e.lower() == str(value).lower()), None)
+            if match is not None:
+                error(file, f"'{field}' value \"{value}\" has wrong casing — values are case-sensitive; use \"{match}\"")
+            else:
+                error(file, f"'{field}' must be one of {', '.join(enum)}; got \"{value}\"")
+
         type_ = doc.get("type")
         if type_ is None:
             error(file, "'type' is required")
         elif type_ not in type_enum:
-            error(file, f"'type' must be one of {', '.join(type_enum)}; got \"{type_}\"")
+            enum_error("type", type_, type_enum)
 
         scope = doc.get("scope")
         if scope is not None and scope not in scope_enum:
-            error(file, f"'scope' must be one of {', '.join(scope_enum)}; got \"{scope}\"")
+            enum_error("scope", scope, scope_enum)
 
         if scope == "Plugin" and isinstance(message, str) and not re.match(plugin_pattern, message):
             head = message.splitlines()[0][:60] if message else ""


### PR DESCRIPTION
## Summary
When a changelog entry has `scope: Plugin`, its `message` must now start with one or more comma-separated plugin names in bold, e.g. `**rate-limiting** Fixed an issue ...` or `**kafka-upstream**, **confluent**: Added ...` (an optional colon after the bold name(s) is accepted).

### Schema (`changelog-schema.json`)
- New draft-07 `if/then` conditional: when `scope` is present and equals `Plugin`, `message` must match

  ```
  ^(?:\*\*[^*\s](?:[^*]*[^*\s])?\*\*)(?:, ?\*\*[^*\s](?:[^*]*[^*\s])?\*\*)*:? 
  ```

  i.e. one or more comma-separated bold names — no leading/trailing whitespace inside each `**...**` block — followed by an optional colon and a mandatory space. Multiple comma-separated names are supported because real kong-ee entries commonly cover several plugins at once. Entries with other scopes (or no scope) are unaffected.
- `additionalProperties: false`: unknown or wrongly-cased keys now fail validation instead of being silently ignored. A real kong-ee changelog contained `Scope: Plugin` (capital S), which previously slipped through as an unrecognized extra key — the entry silently lost its scope and bypassed the Plugin rule. Keys and enum values are case-sensitive; the explain script suggests the correct casing (`did you mean 'scope'?` / `use "bugfix"`).

### Action (`action.yml`)
- **Fix: the action now validates against its own pinned version of the schema.** Previously the composite action re-checked-out `Kong/gateway-changelog` without a `ref`, so the schema always came from `main` regardless of which SHA/tag callers pinned — making it impossible to test schema changes before merge. The schema is now copied from `GITHUB_ACTION_PATH` (the action repo is already downloaded there at the pinned ref), and the extra checkout is removed.
  - ⚠️ Behavior change: schema updates no longer reach callers automatically; callers pinned to a SHA/tag must bump the pin to pick up new rules.
- **New: human-readable, per-rule error messages.** `yaml-schema-checker`'s validator only prints raw regex failures (in-schema custom messages are unsupported), so on failure a follow-up step runs `scripts/explain-changelog-errors.py`, which re-checks the files and emits one `::error file=...` annotation per violation. For Plugin-scope failures it also prints the actual start of the message, and — when the message begins with a quote character — explains that quotes inside a YAML block scalar (`|` / `>`) are part of the content and must be removed (a common authoring mistake found in existing kong-ee changelogs). Example:
  > `scope is "Plugin", so 'message' must start with one or more comma-separated plugin names in bold, followed by a space, e.g. "**rate-limiting** Fixed an issue ..." or "**kafka-upstream**, **confluent**: Added ...". Actual message starts with: '"**service-protection**: Fixed an issue ...'. Note: the message starts with a quote character — quotes inside a YAML block scalar (| or >) are part of the content; remove them.`

  It also flags case-sensitivity mistakes with the correct spelling (`unknown key "Scope" — keys are case-sensitive; did you mean 'scope'?`, `'type' value "Bugfix" has wrong casing — use "bugfix"`).

  Enums, length limits, and the Plugin pattern are read at runtime from the same copied `gateway-changelog/changelog-schema.json` that `yaml-schema-checker` validates against, so the schema remains the single source of truth. `yaml-schema-checker` remains the enforcement gate; the script is best-effort explanation only (degrades to a warning if PyYAML is unavailable).

## Testing
- Schema validated with a draft-07 validator:
  - ✅ `**rate-limiting** fix counter` / `**AI Proxy**: fix streaming` (Plugin) — valid
  - ✅ `**kafka-upstream**, **confluent**: Added ...` and longer comma-separated lists (incl. block-scalar messages with trailing newlines) — valid
  - ❌ `fix counter` (Plugin) — rejected
  - ❌ `"**datakit**: Added ..."` (quote characters as message content) — rejected
  - ❌ `**ai-proxy**fix` (no space after bold), `**AI Proxy **` / `** AI Proxy**` (whitespace at bold edges), `***x**` (malformed bold), `**a**, notbold, **b**:` (non-bold list item) — rejected
  - ✅ `fix counter` with `scope: Core` or no scope — still valid
- Explain script tested locally against valid/invalid sample files — one precise annotation per violation, silent on valid files.
- End-to-end verified from a kong-ee PR pinned to this branch across several iterations: multi-plugin entries pass; all remaining failures are genuine violations — 5 entries missing the plugin-name prefix, 2 entries with quote characters baked into the message content, and 1 entry with `Scope: Plugin` (wrong-case key, caught by `additionalProperties: false` with a "did you mean 'scope'?" hint).
- Copilot's regex refactor (non-capturing groups) verified behavior-identical to the previous pattern across 16 positive/negative cases.

Note: the schema can only enforce the bold-prefix *format*; it cannot verify the name matches a real plugin.

Jira: [KAG-9277](https://konghq.atlassian.net/browse/KAG-9277)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[KAG-9277]: https://konghq.atlassian.net/browse/KAG-9277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ