### PR TITLE
feat(changelog): sync commits from minor branch to release branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 
 cmd/changelog-markdown.tmpl
+
+!CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Project Does
+
+A toolchain for validating and generating `CHANGELOG.md` files from individual YAML changelog entries in Kong Gateway repositories. It has two roles:
+
+1. **GitHub Action** (`action.yml`) — validates changelog YAML files against `changelog-schema.json` in CI. On failure, `scripts/explain-changelog-errors.py` prints human-readable GitHub error annotations.
+2. **CLI tool** (`changelog generate`) — reads YAML changelog files from a repo, resolves associated PRs/Jiras via the GitHub API, and renders a markdown changelog to stdout using `changelog-markdown.tmpl`.
+
+## Build Commands
+
+```bash
+make build      # clean + go generate + go build
+make test       # clean + go generate + go test -v ./...
+make generate   # go generate (copies template into cmd/ for embedding)
+make install    # clean + go generate + go install
+```
+
+The `go generate` step (`cmd/generate.go`) copies `changelog-markdown.tmpl` into `cmd/` so it can be embedded via `//go:embed`. The generated copy (`cmd/changelog-markdown.tmpl`) is gitignored — always run `make generate` before building.
+
+## Architecture
+
+- **`main.go`** — entry point, delegates to `cmd.New()` (urfave/cli app).
+- **`cmd/root.go`** — CLI app definition with a single `generate` subcommand. Version is set here.
+- **`cmd/generate.go`** — core logic: parses YAML entries, resolves each file's original commit via git (handling renames), fetches PR metadata from the GitHub API, extracts Jira IDs from PR bodies, sorts entries by scope priority, and renders the template. Release-line attribution (`releaseLineCandidates` + `fetchCommitContext`): a fix-release branch `next/A.B.C.D` is cut from the minor branch `next/A.B.x.x` and synced by cherry-picking. When `--source-branch` (the minor branch, e.g. `origin/next/A.B.x.x`) is given, every entry is attributed to the PR of its commit **on the minor branch** — the release-line PR, not the upstream/master PR nor the sync PR:
+  - introducing commit **is** on the minor branch (present before the cut) → use it as-is;
+  - introducing commit is **not** on the minor branch (synced in after the cut) → locate its minor-branch counterpart, in order: (1) `git cherry-pick -x` source, when that source is itself on the minor branch; (2) the minor-branch commit that cherry-picked the same upstream source (`FindCherryPickOnBranch`); (3) the minor-branch commit that introduced the entry's changelog `.yml` file (`FindFileOriginOnBranch`) — the file is cherry-picked verbatim, so it identifies the counterpart even when no `-x` trailer was recorded (e.g. a backport applied without `-x`) and regardless of what else the sync commit touched.
+
+  The introducing commit is always kept as the final fallback (`resolveMergedPR`) so no entry is dropped. Without `--source-branch`, the introducing commit is used directly (backward-compatible).
+- **`utils/git.go`** — `FindOriginalCommit` traces a changelog file back through renames to find its original commit SHA. Uses `git log --diff-filter=A` and `git diff-tree -r -M`. `FindCherryPickSource` reads a commit's message and returns the source SHA recorded by `git cherry-pick -x` (`(cherry picked from commit <sha>)`; the last trailer when several hops accumulate). `FindCherryPickOnBranch` finds the commit on a branch that recorded a cherry-pick of a given source SHA (maps a synced-in commit to its minor-branch backport). `FindFileOriginOnBranch` finds the commit on a branch that added a given changelog file — matched at its exact path, then by basename anywhere under `changelog/` — a trailer-independent, diff-independent fallback. `IsAncestor`/`RefExists` gate this on branch reachability (see `cmd/generate.go`).
+- **`utils/utils.go`** — `MatchJiras` extracts Jira ticket IDs (prefixes: FTI, AG, KAG, KM, K8, OLLY, KOKO) from PR body text.
+- **`changelog-schema.json`** — JSON Schema for changelog YAML. Includes a conditional rule: when `scope` is `"Plugin"`, the `message` must start with one or more bold plugin names (e.g., `**rate-limiting** ...`).
+- **`scripts/explain-changelog-errors.py`** — best-effort Python script that re-validates changelogs and emits `::error` annotations with detailed hints (casing mistakes, missing fields, Plugin prefix format).
+
+## Changelog YAML Format
+
+```yaml
+message: "Description of the change"        # required, 1-1000 chars
+type: feature                                # required: feature|bugfix|dependency|deprecation|breaking_change|performance
+scope: Core                                  # optional: Core|Plugin|PDK|Admin API|Performance|Configuration|Clustering|Portal|CLI Command
+prs: [1234]                                  # optional: associated PR numbers
+githubs: [1234]                              # optional: GitHub issue/PR references
+jiras: ["FTI-5678"]                          # optional: Jira ticket IDs (pattern: ^[A-Z]+-[0-9]+$)
+```
+
+When `scope: Plugin`, the message **must** start with bold plugin name(s): `**plugin-name** ...` or `**a**, **b**: ...`.
+
+## Key Details
+
+- Requires `GITHUB_TOKEN` environment variable for the `generate` command (needs read access to Contents, Issues, Metadata, Pull Requests).
+- Scope priority ordering (lower = rendered first): Performance(10) > Configuration(20) > Core(30) > PDK(40) > Plugin(50) > Admin API(60) > Clustering(70) > Default(100).
+- Go version: 1.20. CI runs on `ubuntu-latest`.
+- Releases build cross-platform binaries (linux/darwin/windows × amd64/arm64) via GitHub release trigger.

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -676,7 +676,7 @@ func newGenerateCmd() *cli.Command {
 			repoPath := c.String("repo-path")
 			sourceBranch := c.String("source-branch")
 			if sourceBranch != "" && !utils.RefExists(repoPath, sourceBranch) {
-				Error("source branch %q not found in %s; cherry-pick source attribution disabled", sourceBranch, repoPath)
+				Error("source branch %q not found in %s; cherry-pick source attribution disabled\n", sourceBranch, repoPath)
 				sourceBranch = ""
 			}
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -36,6 +36,13 @@ type GenerateCmdOptions struct {
 
 	ChangelogPaths []string
 
+	// SourceBranch is the minor branch that the fix-release branch being
+	// generated was cut from (e.g. origin/next/3.14.x.x). When set, every entry
+	// is attributed to the PR of its commit on this minor branch — the
+	// release-line (backport) PR — rather than the upstream/master PR or the
+	// sync PR. Empty uses the introducing commit directly (backward-compatible).
+	SourceBranch string
+
 	WithJiras bool
 
 	GithubApiOwner string
@@ -208,6 +215,82 @@ func fetchMergedPullRequestFromCommitMessage(commit string) (*github.PullRequest
 	return nil, nil
 }
 
+// resolveMergedPR finds the merged PR that introduced the given commit, first
+// via the GitHub "list PRs associated with a commit" API and, failing that, by
+// parsing PR references out of the commit message.
+func resolveMergedPR(commit string) (*github.PullRequest, error) {
+	prs, _, err := client.PullRequests.ListPullRequestsWithCommit(context.TODO(), options.GithubApiOwner, options.GithubApiRepo, commit, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch pulls for commit %s: %v", commit, err)
+	}
+
+	mergedPR := findMergedPullRequest(prs)
+	if mergedPR == nil {
+		mergedPR, err = fetchMergedPullRequestFromCommitMessage(commit)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve merged PR from commit message: %v", err)
+		}
+		if debug && mergedPR != nil {
+			Debug("resolved merged PR #%d from commit message for %s", mergedPR.GetNumber(), commit)
+		}
+	}
+
+	return mergedPR, nil
+}
+
+// releaseLineCandidates returns the commit SHAs to resolve a changelog entry's
+// PR from, in priority order, so the entry is attributed to the PR of its commit
+// on the minor branch (options.SourceBranch, e.g. next/3.14.x.x) — the
+// release-line PR — rather than the upstream/master PR or the sync PR.
+//
+// A fix-release branch (e.g. next/3.14.0.9) is cut from the minor branch and
+// then synced by cherry-picking. The introducing commit is either:
+//
+//   - already on the minor branch (present before the cut) — use it as-is; or
+//   - synced in after the cut — locate its counterpart on the minor branch by,
+//     in order: (1) the `git cherry-pick -x` trailer, when the recorded source
+//     is itself on the minor branch; (2) the minor-branch commit that
+//     cherry-picked the same upstream source (the backport commit); (3) the
+//     minor-branch commit that introduced the entry's changelog file, which is
+//     cherry-picked verbatim during the sync and so identifies the counterpart
+//     even when no trailer was recorded (e.g. a backport applied without -x) and
+//     regardless of what else the sync commit touched.
+//
+// The introducing commit is always kept as the last fallback so an entry is
+// never dropped when the preferred commit has no resolvable merged PR.
+func releaseLineCandidates(commit, filename string) []string {
+	if options.SourceBranch == "" || utils.IsAncestor(options.RepoPath, commit, options.SourceBranch) {
+		return []string{commit}
+	}
+
+	// Prefer the recorded cherry-pick provenance (exact and cheap): the source
+	// itself when it is on the minor branch, else the minor-branch commit that
+	// backported the same source.
+	src := utils.FindCherryPickSource(options.RepoPath, commit)
+	if src != "" {
+		if utils.IsAncestor(options.RepoPath, src, options.SourceBranch) {
+			return []string{src, commit}
+		}
+		if onBranch := utils.FindCherryPickOnBranch(options.RepoPath, options.SourceBranch, src); onBranch != "" {
+			return []string{onBranch, commit}
+		}
+	}
+
+	// No usable trailer mapping (no trailer, or the source is upstream with no
+	// minor-branch backport referencing it): find the minor-branch commit that
+	// introduced this entry's changelog file.
+	if origin := utils.FindFileOriginOnBranch(options.RepoPath, options.SourceBranch, filename); origin != "" {
+		return []string{origin, commit}
+	}
+
+	// Last resort: the recorded upstream source (if any) as the best available
+	// origin, otherwise the introducing commit itself.
+	if src != "" {
+		return []string{src, commit}
+	}
+	return []string{commit}
+}
+
 func fetchCommitContext(filename string) (ctx CommitContext, err error) {
 	commit, err := utils.FindOriginalCommit(options.RepoPath, filename)
 	if err != nil {
@@ -218,24 +301,25 @@ func fetchCommitContext(filename string) (ctx CommitContext, err error) {
 		Debug("file %s original commit: %s", filename, commit)
 	}
 
-	prs, _, err := client.PullRequests.ListPullRequestsWithCommit(context.TODO(), options.GithubApiOwner, options.GithubApiRepo, commit, nil)
-	if err != nil {
-		return ctx, fmt.Errorf("failed to fetch pulls for commit %s: %v", commit, err)
+	candidates := releaseLineCandidates(commit, filename)
+	if debug && candidates[0] != commit {
+		Debug("commit %s attributed to release-line commit %s (via %v)", commit, candidates[0], candidates)
 	}
 
-	mergedPR := findMergedPullRequest(prs)
-	if mergedPR == nil {
-		mergedPR, err = fetchMergedPullRequestFromCommitMessage(commit)
+	var mergedPR *github.PullRequest
+	for _, sha := range candidates {
+		mergedPR, err = resolveMergedPR(sha)
 		if err != nil {
-			return ctx, fmt.Errorf("failed to resolve merged PR from commit message: %v", err)
+			return ctx, err
 		}
-		if debug && mergedPR != nil {
-			Debug("resolved merged PR #%d from commit message for %s", mergedPR.GetNumber(), commit)
+		if mergedPR != nil {
+			ctx.SHA = sha
+			break
 		}
 	}
 
 	if mergedPR == nil {
-		return ctx, &MissingPullRequestError{CommitSHA: commit}
+		return ctx, &MissingPullRequestError{CommitSHA: ctx.SHA}
 	}
 
 	ctx.PrCtx = PullRequestContext{
@@ -284,7 +368,11 @@ func parseGithub(githubNos []int) []*Github {
 	for _, no := range githubNos {
 		github := &Github{
 			Name: fmt.Sprintf("#%d", no),
-			Link: fmt.Sprintf("https://github.com/%s/issues/%d", options.GithubIssueRepo, no),
+			// Use the /pull/ form so the common case (a resolved PR or a `prs`
+			// entry) links straight to the PR. GitHub redirects /pull/<n> to
+			// /issues/<n> when <n> is actually an issue, so genuine issue
+			// references in the `githubs` field still resolve correctly.
+			Link: fmt.Sprintf("https://github.com/%s/pull/%d", options.GithubIssueRepo, no),
 		}
 		list = append(list, github)
 	}
@@ -563,6 +651,11 @@ func newGenerateCmd() *cli.Command {
 				Usage:    "Display Jira links",
 				Required: false,
 			},
+			&cli.StringFlag{
+				Name:     "source-branch",
+				Usage:    "The minor branch the fix-release branch was cut from (origin/next/3.14.x.x). When set, each entry is attributed to the PR of its commit on this branch (the release-line/backport PR) instead of the upstream/master or sync PR.",
+				Required: false,
+			},
 		},
 		Action: func(c *cli.Context) error {
 			githubToken := os.Getenv("GITHUB_TOKEN")
@@ -580,14 +673,22 @@ func newGenerateCmd() *cli.Command {
 
 			parts := strings.Split(c.String("github-api-repo"), "/")
 
+			repoPath := c.String("repo-path")
+			sourceBranch := c.String("source-branch")
+			if sourceBranch != "" && !utils.RefExists(repoPath, sourceBranch) {
+				Error("source branch %q not found in %s; cherry-pick source attribution disabled", sourceBranch, repoPath)
+				sourceBranch = ""
+			}
+
 			options = GenerateCmdOptions{
-				RepoPath:        c.String("repo-path"),
+				RepoPath:        repoPath,
 				ChangelogPaths:  c.StringSlice("changelog-paths"),
 				Title:           c.String("title"),
 				GithubApiOwner:  parts[0],
 				GithubApiRepo:   parts[1],
 				GithubIssueRepo: c.String("github-issue-repo"),
 				WithJiras:       c.Bool("with-jiras"),
+				SourceBranch:    sourceBranch,
 			}
 
 			return Generate()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,8 @@ func New() *cli.App {
 		Name:        "changelog",
 		Usage:       "changelog [command]",
 		Description: "A changelog tool to manage changelog.",
-		Version:     "2.0.3",
+		// whenever you bump the version, please update the
+		Version: "2.1.0", // "REQUIRED_VERSION" of changelog/Makefile in EE repo
 
 		// global flags
 		Flags: []cli.Flag{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,8 +14,9 @@ func New() *cli.App {
 		Name:        "changelog",
 		Usage:       "changelog [command]",
 		Description: "A changelog tool to manage changelog.",
-		// whenever you bump the version, please update the
-		Version: "2.1.0", // "REQUIRED_VERSION" of changelog/Makefile in EE repo
+		// Whenever you bump the version, also update the REQUIRED_VERSION in
+		// changelog/Makefile in the EE repository.
+		Version: "2.1.0",
 
 		// global flags
 		Flags: []cli.Flag{

--- a/utils/git.go
+++ b/utils/git.go
@@ -5,8 +5,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
+
+// cherryPickTrailerPattern matches the trailer that `git cherry-pick -x`
+// appends to a commit message, e.g.
+// "(cherry picked from commit 90314b05fd3073ba6991ff76cc21ba1dff569011)".
+var cherryPickTrailerPattern = regexp.MustCompile(`\(cherry picked from commit ([0-9a-f]{7,40})\)`)
 
 type NoCommitsFoundError struct {
 	FileName string
@@ -145,6 +151,121 @@ func findOldestCommit(workingDir, filename string) string {
 	}
 	lines := strings.Split(trimmed, "\n")
 	return strings.TrimSpace(lines[len(lines)-1])
+}
+
+// FindCherryPickSource returns the source commit SHA recorded by
+// `git cherry-pick -x` in the given commit's message, or "" when the commit is
+// not a recorded cherry-pick (or cannot be read locally).
+//
+// A fix-release branch (e.g. next/3.14.0.9) is cut from a minor branch
+// (next/3.14.x.x) and then synced by cherry-picking commits into it. Each such
+// cherry-pick carries a "(cherry picked from commit <sha>)" trailer pointing at
+// the commit it was cherry-picked from. When a change is cherry-picked across
+// several hops, the message accumulates one trailer per hop in order; the last
+// trailer is the most recent hop and identifies the immediate source, so that
+// is the one returned.
+func FindCherryPickSource(workingDir, commit string) string {
+	cmd := exec.Command("git", "log", "-1", "--no-show-signature", "--format=%B", commit)
+	cmd.Dir = workingDir
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	matches := cherryPickTrailerPattern.FindAllStringSubmatch(string(output), -1)
+	if len(matches) == 0 {
+		return ""
+	}
+
+	return matches[len(matches)-1][1]
+}
+
+// FindCherryPickOnBranch returns the SHA of the most recent commit reachable
+// from branch whose message records a `git cherry-pick -x` of sourceSHA (i.e.
+// contains "(cherry picked from commit <sourceSHA>)"), or "" if none is found.
+//
+// It maps a commit cherry-picked into a fix-release branch after the cut back to
+// the equivalent commit on the minor branch: both cherry-picked the same
+// upstream (e.g. master) source, so both carry a trailer referencing it. This
+// lets an entry be attributed to the minor-branch backport PR rather than the
+// upstream/master PR.
+func FindCherryPickOnBranch(workingDir, branch, sourceSHA string) string {
+	cmd := exec.Command("git", "log", "--no-show-signature", "--fixed-strings",
+		"--grep=cherry picked from commit "+sourceSHA, "--format=%H", branch)
+	cmd.Dir = workingDir
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return ""
+	}
+
+	return strings.TrimSpace(strings.Split(trimmed, "\n")[0])
+}
+
+// addedCommitOnBranch returns the most recent commit reachable from branch that
+// added a path matching pathspec, or "" when none is found.
+func addedCommitOnBranch(workingDir, branch, pathspec string) string {
+	cmd := exec.Command("git", "log", branch, "--diff-filter=A", "--no-show-signature",
+		"--format=%H", "--", pathspec)
+	cmd.Dir = workingDir
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return ""
+	}
+
+	return strings.TrimSpace(strings.Split(trimmed, "\n")[0])
+}
+
+// FindFileOriginOnBranch returns the SHA of the commit reachable from branch
+// that introduced (added) file, or "" when none is found.
+//
+// A changelog entry is identified by its YAML file, which is cherry-picked
+// verbatim when a change is synced from the minor branch into a fix-release
+// branch. The commit that added that same file on the minor branch is therefore
+// the entry's release-line origin — a signal that, unlike a whole-commit
+// patch-id, is unaffected by conflict resolution or a differing set of files
+// touched by the sync. The file is matched first at its exact path, then (in
+// case it lives under a different changelog subdirectory on the branch — e.g. a
+// version folder rather than unreleased) by basename anywhere under changelog/.
+func FindFileOriginOnBranch(workingDir, branch, file string) string {
+	if sha := addedCommitOnBranch(workingDir, branch, file); sha != "" {
+		return sha
+	}
+
+	base := filepath.Base(file)
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		return ""
+	}
+
+	// ":(top,glob)" anchors to the repo root (regardless of workingDir) and lets
+	// "**" span directories, so the basename is matched anywhere under changelog/.
+	return addedCommitOnBranch(workingDir, branch, ":(top,glob)changelog/**/"+base)
+}
+
+// RefExists reports whether ref resolves to a commit in the repository.
+func RefExists(workingDir, ref string) bool {
+	cmd := exec.Command("git", "rev-parse", "--verify", "--quiet", ref+"^{commit}")
+	cmd.Dir = workingDir
+	return cmd.Run() == nil
+}
+
+// IsAncestor reports whether commit is an ancestor of (i.e. reachable from) ref.
+// Returns false when either revision is unknown or the check cannot be run, so
+// callers should validate ref with RefExists first when a missing ref must not
+// be treated as "not an ancestor".
+func IsAncestor(workingDir, commit, ref string) bool {
+	cmd := exec.Command("git", "merge-base", "--is-ancestor", commit, ref)
+	cmd.Dir = workingDir
+	return cmd.Run() == nil
 }
 
 // FindOriginalCommit traces back through renames to find

--- a/utils/git_test.go
+++ b/utils/git_test.go
@@ -1,0 +1,209 @@
+package utils
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v failed: %v", args, err)
+	}
+	return string(out)
+}
+
+// commitWithMessage creates an empty commit with the given message and returns its SHA.
+func commitWithMessage(t *testing.T, dir, message string) string {
+	t.Helper()
+	runGit(t, dir, "commit", "--allow-empty", "--no-gpg-sign", "-m", message)
+	return strings.TrimSpace(runGit(t, dir, "rev-parse", "HEAD"))
+}
+
+// commitFile writes path (creating parent dirs) with content, commits it, and
+// returns the new SHA.
+func commitFile(t *testing.T, dir, path, content, msg string) string {
+	t.Helper()
+	full := filepath.Join(dir, path)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", path)
+	runGit(t, dir, "commit", "--no-gpg-sign", "-m", msg)
+	return strings.TrimSpace(runGit(t, dir, "rev-parse", "HEAD"))
+}
+
+func newRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-q")
+	return dir
+}
+
+func TestFindCherryPickSource(t *testing.T) {
+	dir := newRepo(t)
+
+	tests := []struct {
+		name    string
+		message string
+		want    string
+	}{
+		{
+			name:    "no trailer",
+			message: "fix(core): a normal commit (#123)",
+			want:    "",
+		},
+		{
+			name:    "single trailer",
+			message: "fix(debugger): span names (#19377)\n\n(cherry picked from commit 90314b05fd3073ba6991ff76cc21ba1dff569011)",
+			want:    "90314b05fd3073ba6991ff76cc21ba1dff569011",
+		},
+		{
+			name:    "multiple trailers returns the last (most recent hop)",
+			message: "feat: thing\n\n(cherry picked from commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)\n(cherry picked from commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)",
+			want:    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sha := commitWithMessage(t, dir, tc.message)
+			got := FindCherryPickSource(dir, sha)
+			if got != tc.want {
+				t.Fatalf("FindCherryPickSource() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFindCherryPickSourceUnknownCommit(t *testing.T) {
+	dir := newRepo(t)
+	if got := FindCherryPickSource(dir, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"); got != "" {
+		t.Fatalf("FindCherryPickSource() for unknown commit = %q, want \"\"", got)
+	}
+}
+
+func TestFindCherryPickOnBranch(t *testing.T) {
+	dir := newRepo(t)
+
+	// The upstream (master) source commit.
+	src := commitWithMessage(t, dir, "fix: original change")
+
+	// A minor-branch backport that cherry-picked src with -x.
+	runGit(t, dir, "checkout", "-q", "-b", "minor")
+	backport := commitWithMessage(t, dir,
+		"[backport] fix: original change\n\n(cherry picked from commit "+src+")")
+
+	// An unrelated commit on the same branch, so we exercise the grep filter.
+	commitWithMessage(t, dir, "chore: unrelated")
+
+	if got := FindCherryPickOnBranch(dir, "minor", src); got != backport {
+		t.Fatalf("FindCherryPickOnBranch() = %q, want %q (the backport commit)", got, backport)
+	}
+
+	// A source never cherry-picked onto the branch yields "".
+	if got := FindCherryPickOnBranch(dir, "minor", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"); got != "" {
+		t.Fatalf("FindCherryPickOnBranch() for absent source = %q, want \"\"", got)
+	}
+}
+
+func TestFindFileOriginOnBranch(t *testing.T) {
+	dir := newRepo(t)
+	base := commitFile(t, dir, "README", "base\n", "base")
+
+	// The minor branch introduces the entry's changelog file (plus an unrelated
+	// changelog entry, so the lookup isn't trivial).
+	runGit(t, dir, "checkout", "-q", "-b", "minor", base)
+	origin := commitFile(t, dir, "changelog/unreleased/kong-ee/fix-thing.yml", "message: fixed\n", "fix: thing (#1)")
+	commitFile(t, dir, "changelog/unreleased/kong-ee/other.yml", "message: other\n", "feat: other (#2)")
+
+	entry := "changelog/unreleased/kong-ee/fix-thing.yml"
+
+	// Exact-path match.
+	if got := FindFileOriginOnBranch(dir, "minor", entry); got != origin {
+		t.Fatalf("FindFileOriginOnBranch(exact) = %q, want %q", got, origin)
+	}
+
+	// Basename fallback: on the query side the entry sits under a version folder,
+	// but on the branch it is still under unreleased/ (same basename).
+	moved := "changelog/3.14.0.10/kong-ee/fix-thing.yml"
+	if got := FindFileOriginOnBranch(dir, "minor", moved); got != origin {
+		t.Fatalf("FindFileOriginOnBranch(basename) = %q, want %q", got, origin)
+	}
+
+	// A changelog file never added on the branch has no origin.
+	if got := FindFileOriginOnBranch(dir, "minor", "changelog/unreleased/kong-ee/absent.yml"); got != "" {
+		t.Fatalf("FindFileOriginOnBranch(absent) = %q, want \"\"", got)
+	}
+
+	// The real workflow runs with --repo-path pointing at the changelog/ subdir,
+	// so paths are relative to it. Both the exact path and the basename fallback
+	// (":(top,...)") must still resolve.
+	sub := filepath.Join(dir, "changelog")
+	if got := FindFileOriginOnBranch(sub, "minor", "unreleased/kong-ee/fix-thing.yml"); got != origin {
+		t.Fatalf("FindFileOriginOnBranch(subdir exact) = %q, want %q", got, origin)
+	}
+	if got := FindFileOriginOnBranch(sub, "minor", "3.14.0.10/kong-ee/fix-thing.yml"); got != origin {
+		t.Fatalf("FindFileOriginOnBranch(subdir basename) = %q, want %q", got, origin)
+	}
+}
+
+func TestRefExists(t *testing.T) {
+	dir := newRepo(t)
+	base := commitWithMessage(t, dir, "base")
+	runGit(t, dir, "branch", "minor")
+
+	if !RefExists(dir, "minor") {
+		t.Error("RefExists(minor) = false, want true")
+	}
+	if !RefExists(dir, base) {
+		t.Error("RefExists(<sha>) = false, want true")
+	}
+	if RefExists(dir, "origin/next/9.9.x.x") {
+		t.Error("RefExists(<missing>) = true, want false")
+	}
+}
+
+func TestIsAncestor(t *testing.T) {
+	dir := newRepo(t)
+
+	// base -> minor branch cut here, then master and minor diverge.
+	base := commitWithMessage(t, dir, "base")
+	runGit(t, dir, "branch", "minor")
+
+	// A commit only on the "minor" branch (models a pre-cut backport).
+	runGit(t, dir, "checkout", "-q", "minor")
+	onMinor := commitWithMessage(t, dir, "on minor only")
+
+	// A commit only on the default branch after the cut (models a synced-in commit).
+	runGit(t, dir, "checkout", "-q", "-")
+	synced := commitWithMessage(t, dir, "synced after cut")
+
+	if !IsAncestor(dir, base, "minor") {
+		t.Error("base should be an ancestor of minor")
+	}
+	if !IsAncestor(dir, onMinor, "minor") {
+		t.Error("onMinor should be an ancestor of minor")
+	}
+	if IsAncestor(dir, synced, "minor") {
+		t.Error("synced commit should NOT be an ancestor of minor")
+	}
+	if IsAncestor(dir, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "minor") {
+		t.Error("unknown commit should not be reported as an ancestor")
+	}
+}


### PR DESCRIPTION
When commits are synced from a source minor branch (e.g. `next/3.14.x.x`) to a target release branch (e.g. `release/3.14.0.10`), resolve the commits and PRs introducing the changelog file on the source minor branch instead of the release branch in the following order of precedence:

1. If changelog is generated against the minor branch, [BASE_BRANCH](https://github.com/Kong/kong-ee/blob/5f9062397a87cd79fc2cb747bfa9be4e8d9e5741/changelog/Makefile#L11) is the minor branch and [SOURCE_BRANCH](https://github.com/Kong/kong-ee/pull/20377/files#diff-d645bd78c790fa196f276a2fc1fb8f8e37a1be751a9f2f679f777035878a36c7R24) is unset.
   1. Pick the resolved commit introducing the changelog file on the minor branch. Same as before.
3. If the changelog is generated against the release branch, [BASE_BRANCH](https://github.com/Kong/kong-ee/blob/5f9062397a87cd79fc2cb747bfa9be4e8d9e5741/changelog/Makefile#L11) is the release branch, and [SOURCE_BRANCH](https://github.com/Kong/kong-ee/pull/20377/files#diff-d645bd78c790fa196f276a2fc1fb8f8e37a1be751a9f2f679f777035878a36c7R24) is the minor branch.
   1. If the resolved commit has landed on the minor branch before the release branch cut.
      1. Pick the resolved commit. This commit is automatically carried over to the release branch upon cut.
   3. If the resolved commit is cherry-picked to the release branch after cut.
      1. Extract the commit from commit message of the resolved commit on the release branch by inspecting the pattern "(cherry picked from commit sha1)" if the extracted commit has landed on the minor branch before cut. The resolved commit was cherry-picked with the `-x` option.
      2. Pick the commit on the minor branch that has the same pattern "(cherry picked from commit sha1)".
      3. Pick the commit on the minor branch that added the changelog file if the resolved commit does not have the pattern.
4. Fallback to the commit on the release branch.

This PR also bumps version to `2.1.0`.

Verfied by https://github.com/Kong/kong-ee/pull/20366, https://github.com/Kong/kong-ee/pull/20382 and https://github.com/Kong/kong-ee/pull/20384.

Blocks https://github.com/Kong/kong-ee/pull/20377 and https://github.com/Kong/kong-ee/pull/20404.

Should bump the changelog version in workflow as well. See https://github.com/Kong/kong-ee/pull/20209.

FTI-7758