### PR TITLE
feat(schema): allow optional "**X Only**." prefix in Plugin message

### DIFF
--- a/changelog-schema.json
+++ b/changelog-schema.json
@@ -74,8 +74,8 @@
   "then": {
     "properties": {
       "message": {
-        "pattern": "^(?:\\*\\*[^*\\s](?:[^*]*[^*\\s])?\\*\\*)(?:, ?\\*\\*[^*\\s](?:[^*]*[^*\\s])?\\*\\*)*:? ",
-        "description": "When scope is Plugin, message must start with one or more comma-separated plugin names in bold, e.g. \"**rate-limiting** ...\" or \"**kafka-upstream**, **confluent**: ...\""
+        "pattern": "^(?:\\*\\*[^*\\s][^*]* Only\\*\\*\\. )?(?:\\*\\*[^*\\s](?:[^*]*[^*\\s])?\\*\\*)(?:, ?\\*\\*[^*\\s](?:[^*]*[^*\\s])?\\*\\*)*:? ",
+        "description": "When scope is Plugin, message must start with one or more comma-separated plugin names in bold, e.g. \"**rate-limiting** ...\" or \"**kafka-upstream**, **confluent**: ...\". An optional \"**<X> Only**. \" prefix (e.g. \"**Konnect Only**. \") may precede the plugin names."
       }
     }
   }

--- a/scripts/explain-changelog-errors.py
+++ b/scripts/explain-changelog-errors.py
@@ -105,6 +105,8 @@ def main():
                         "comma-separated plugin names in bold, followed by a space, e.g. "
                         "\"**rate-limiting** Fixed an issue ...\" or "
                         "\"**kafka-upstream**, **confluent**: Added ...\". "
+                        "An optional \"**<X> Only**. \" prefix (e.g. \"**Konnect Only**. \") "
+                        "may precede the plugin names. "
                         f"Actual message starts with: {head!r}.{hint}")
 
         for key in ("prs", "githubs"):


### PR DESCRIPTION
## Summary
Extends the `scope: Plugin` message validation to accept an optional bold `**<X> Only**. ` prefix before the plugin name(s).

Example now accepted:
```yaml
message: |
  **Konnect Only**. **datakit**: Added node source and runtime phase metadata to Datakit tracing events.
type: bugfix
scope: Plugin
```

## Changes
- `changelog-schema.json`: added optional `^(?:\*\*[^*\s][^*]*Only\*\*\. )?` prefix to the message pattern and updated the description.
- `scripts/explain-changelog-errors.py`: extended the error hint (the script reads the pattern from the schema, so validation logic is unchanged).

## Behavior
- Prefix is optional — existing messages (`**datakit**: ...`) still pass.
- Requires the bold prefix text to end in `Only` (e.g. `**Konnect Only**`, `**Enterprise Only**`), followed by `. `.
- Still requires a real bold plugin name after the prefix — `**Konnect Only**. bad no plugin` correctly fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

KAG-9277